### PR TITLE
Don't spam admins with sbuild-update output when things go well

### DIFF
--- a/ansible/roles/worker/tasks/main.yml
+++ b/ansible/roles/worker/tasks/main.yml
@@ -1,5 +1,9 @@
-- name: Install sbuild
-  apt: package=sbuild state=present
+- name: Install sbuild and cronic
+  apt:
+    package:
+      - sbuild
+      - cronic
+    state: present
 - name: Install lintian-brush dependencies
   apt:
     package:
@@ -38,7 +42,7 @@
   cron:
     name: "update schroot for {{ item['name'] }}"
     special_time: daily
-    job: sbuild-update -udcar "{{ item['chroot'] }}"
+    job: cronic sbuild-update -udcar "{{ item['chroot'] }}"
   with_items: "{{ janitor_distributions }}"
 - name: janitor in sbuild group
   user:


### PR DESCRIPTION
cronic will catch output and will print it only if it detects output on stderr or if the command returned with a non-zero exit status.

That way admins get a mail only when something has gone wrong.