### PR TITLE
removed old traces of python2 support

### DIFF
--- a/janitor/package_metadata.py
+++ b/janitor/package_metadata.py
@@ -17,8 +17,6 @@
 
 """Importing of upstream metadata."""
 
-from __future__ import absolute_import
-
 import logging
 from typing import List, Tuple, Sequence
 

--- a/janitor/reprocess_logs.py
+++ b/janitor/reprocess_logs.py
@@ -15,8 +15,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-from __future__ import absolute_import
-
 from datetime import timedelta
 import logging
 from typing import Optional

--- a/janitor/schedule.py
+++ b/janitor/schedule.py
@@ -15,8 +15,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-from __future__ import absolute_import
-
 __all__ = [
     "bulk_add_to_queue",
 ]

--- a/janitor/tests/__init__.py
+++ b/janitor/tests/__init__.py
@@ -15,8 +15,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-from __future__ import absolute_import
-
 import unittest
 
 


### PR DESCRIPTION
this pr removes all traces of Python2 support, namely the `__future__.absolute_import` which is not needed in the supported python3 versions.