### PR TITLE
Use consistent URL for python_apt in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -87,7 +87,7 @@ dev =
     types-PyYAML
     types-protobuf
 debian =
-    python-apt@git+https://salsa.debian.org/apt-team/python-apt
+    python-apt@git+https://salsa.debian.org/apt-team/python-apt.git
     python_debian
     debmutate@git+https://salsa.debian.org/jelmer/debmutate
     silver-platter[debian]@git+https://github.com/jelmer/silver-platter


### PR DESCRIPTION
Use consistent URL for python_apt in setup.cfg.
