### PR TITLE
Add assert for nothing-new-to-do when there is no resume branch

### DIFF
--- a/janitor/runner.py
+++ b/janitor/runner.py
@@ -2420,7 +2420,7 @@ async def next_item(
                     # but we don't have access to the history here (and the worker doesn't have access
                     # to recent runs). Maybe we can provide the worker with a revision => run_id dict
                     # and let it determine resume_from?
-                    resume_branch = None
+                    pass
         else:
             resume = None
 

--- a/janitor/worker.py
+++ b/janitor/worker.py
@@ -953,6 +953,10 @@ def run_worker(
             except WorkerFailure as e:
                 if e.code == "nothing-to-do":
                     if ws.changes_since_main():
+                        # This should only ever happen if we were resuming
+                        assert ws.resume_branch is not None, \
+                            ("Found existing changes despite not having resumed. "
+                             f"Mainline: {ws.main_branch_revid!r}, local: {ws.local_tree.branch.last_revision()!r}")
                         raise WorkerFailure(
                             "nothing-new-to-do", e.description, stage=("codemod", ), transient=False) from e
                     elif force_build:


### PR DESCRIPTION
Add assert for nothing-new-to-do when there is no resume branch
