### PR TITLE
python3.11 compat: Don't pass coroutines to asyncio.wait

### DIFF
--- a/janitor/differ.py
+++ b/janitor/differ.py
@@ -538,14 +538,14 @@ where
 """
         )
         for row in rows:
-            todo.append(precache(
+            todo.append(asyncio.create_task(precache(
                 request.app['artifact_manager'],
                 row[1], row[0],
                 task_memory_limit=request.app['task_memory_limit'],
                 task_timeout=request.app['task_timeout'],
                 diffoscope_cache_path=request.app['diffoscope_cache_path'],
                 debdiff_cache_path=request.app['debdiff_cache_path'],
-                diffoscope_command=request.app['diffoscope_command']))
+                diffoscope_command=request.app['diffoscope_command'])))
 
 
     async def _precache_all():

--- a/janitor/site/cupboard/api.py
+++ b/janitor/site/cupboard/api.py
@@ -326,7 +326,7 @@ WHERE
 
     async def do_reprocess():
         todo = [
-            reprocess_run_logs(
+            asyncio.create_task(reprocess_run_logs(
                 db=request.app['pool'],
                 logfile_manager=request.app['logfile_manager'],
                 package=row['package'], campaign=row['campaign'], log_id=row['id'],
@@ -337,7 +337,7 @@ WHERE
                 process_fns=[
                     ('dist-', DIST_LOG_FILENAME, process_dist_log),
                     ('build-', BUILD_LOG_FILENAME, process_sbuild_log)],
-                dry_run=dry_run, reschedule=reschedule)
+                dry_run=dry_run, reschedule=reschedule))
             for row in rows]
         for i in range(0, len(todo), 100):
             await asyncio.wait(set(todo[i : i + 100]))


### PR DESCRIPTION
python3.11 compat: Don't pass coroutines to asyncio.wait
