### PR TITLE
Fix a call to .fetchrow

### DIFF
--- a/janitor/publish.py
+++ b/janitor/publish.py
@@ -3268,7 +3268,7 @@ FROM
     run
 WHERE id = $1
 """
-    row = await conn.fetch(query, run_id)
+    row = await conn.fetchrow(query, run_id)
     if row:
         return state.Run.from_row(row)
     return None


### PR DESCRIPTION
Fix a call to .fetchrow

I'm not sure how this ever worked; perhaps [0] on a list of rows used to return
the first cell of the first row?
