### PR TITLE
Add missing "suite" attribute to done-list

### DIFF
--- a/janitor/site/pkg.py
+++ b/janitor/site/pkg.py
@@ -375,7 +375,7 @@ async def generate_done_list(
         runs.append(run)
 
     return {
-        "oldest": oldest, "runs": runs, "campaign": campaign,
+        "oldest": oldest, "runs": runs, "suite": suite, "campaign": campaign,
         "since": since}
 
 


### PR DESCRIPTION
Fixes the broken navigation panel in Debian Janitor.
