### PR TITLE
Downgrade worker's axum@0.7.9

### DIFF
--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -12,7 +12,6 @@ default-run = "janitor-worker"
 [dependencies]
 url = { workspace = true, features = ["serde"] }
 tokio = { workspace = true, features = ["full"] }
-axum = { workspace = true }
 reqwest = { workspace = true, features = ["json", "multipart"] }
 backoff = { version = "0.4", features = ["tokio"] }
 serde_json = "1"
@@ -27,6 +26,7 @@ breezyshim.workspace = true
 silver-platter = { workspace = true, features = ["debian"] }
 debian-analyzer = { workspace = true, optional = true }
 shlex = "1.3.0"
+axum = "0.7.9"   # Depends on axum-core v0.4.5, which is the same for askama_axum
 askama_axum = { version = "0.4.0", features = ["serde-json", "serde-yaml", "humansize", "urlencode", "markdown"] }
 nix = { version = "0.29.0", features = ["fs"] }
 percent-encoding = "2.3.1"


### PR DESCRIPTION
## Before

```console
$ cargo clean; RUSTFLAGS=-Awarnings cargo build --manifest-path worker/Cargo.toml
     Removed 5344 files, 3.0GiB total
   Compiling proc-macro2 v1.0.92
   Compiling unicode-ident v1.0.14
[...]
   Compiling askama_axum v0.4.0
   Compiling ognibuild v0.0.32 (https://github.com/jelmer/ognibuild.git#0a5e3772)
   Compiling janitor-worker v0.0.0 (/tmp/janitor/worker)
error[E0308]: mismatched types
  --> worker/src/web.rs:54:5
   |
30 |   async fn index(State(state): State<Arc<RwLock<AppState>>>) -> Response {
   |                                                                 -------- expected `axum::http::Response<axum::body::Body>` because of return type
...
54 | /     IndexTemplate {
55 | |         assignment: state.assignment.as_ref(),
56 | |         lognames,
57 | |         metadata: state.metadata.as_ref(),
58 | |     }
59 | |     .into_response()
   | |____________________^ expected `axum::body::Body`, found `axum_core::body::Body`
   |
   = note: `axum_core::body::Body` and `axum::body::Body` have similar names, but are actually distinct types
note: `axum_core::body::Body` is defined in crate `axum_core`
  --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/axum-core-0.4.5/src/body.rs:39:1
   |
39 | pub struct Body(BoxBody);
   | ^^^^^^^^^^^^^^^
note: `axum::body::Body` is defined in crate `axum_core`
  --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/axum-core-0.5.0/src/body.rs:39:1
   |
39 | pub struct Body(BoxBody);
   | ^^^^^^^^^^^^^^^
   = note: perhaps two different versions of crate `axum_core` are being used?

error[E0599]: no method named `into_response` found for struct `axum::Json<Vec<std::string::String>>` in the current scope
   --> worker/src/web.rs:103:49
    |
103 |         Some("application/json") => Json(names).into_response(),
    |                                                 ^^^^^^^^^^^^^
    |
note: there are multiple different versions of crate `axum_core` in the dependency graph
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/axum-core-0.5.0/src/response/into_response.rs:112:1
    |
112 | pub trait IntoResponse {
    | ^^^^^^^^^^^^^^^^^^^^^^ this is the trait that is needed
...
115 |     fn into_response(self) -> Response;
    |     ----------------------------------- the method is available for `axum::Json<Vec<std::string::String>>` here
    |
   ::: worker/src/web.rs:2:5
    |
2   | use askama_axum::IntoResponse;
    |     ------------------------- `IntoResponse` imported here doesn't correspond to the right version of crate `axum_core`
    |
   ::: /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/axum-core-0.4.5/src/response/into_response.rs:112:1
    |
112 | pub trait IntoResponse {
    | ---------------------- this is the trait that was imported
help: there is a method `into_py` with a similar name, but with different arguments
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/pyo3-0.22.6/src/conversion.rs:168:5
    |
168 |     fn into_py(self, py: Python<'_>) -> T;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0599]: no method named `into_response` found for struct `axum::Json<Vec<std::string::String>>` in the current scope
   --> worker/src/web.rs:141:49
    |
141 |         Some("application/json") => Json(names).into_response(),
    |                                                 ^^^^^^^^^^^^^
    |
note: there are multiple different versions of crate `axum_core` in the dependency graph
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/axum-core-0.5.0/src/response/into_response.rs:112:1
    |
112 | pub trait IntoResponse {
    | ^^^^^^^^^^^^^^^^^^^^^^ this is the trait that is needed
...
115 |     fn into_response(self) -> Response;
    |     ----------------------------------- the method is available for `axum::Json<Vec<std::string::String>>` here
    |
   ::: worker/src/web.rs:2:5
    |
2   | use askama_axum::IntoResponse;
    |     ------------------------- `IntoResponse` imported here doesn't correspond to the right version of crate `axum_core`
    |
   ::: /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/axum-core-0.4.5/src/response/into_response.rs:112:1
    |
112 | pub trait IntoResponse {
    | ---------------------- this is the trait that was imported
help: there is a method `into_py` with a similar name, but with different arguments
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/pyo3-0.22.6/src/conversion.rs:168:5
    |
168 |     fn into_py(self, py: Python<'_>) -> T;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0599]: no method named `into_response` found for tuple `(StatusCode, HeaderMap, axum::body::Body)` in the current scope
   --> worker/src/web.rs:204:37
    |
204 |     (StatusCode::OK, headers, body).into_response()
    |                                     ^^^^^^^^^^^^^ method not found in `(StatusCode, HeaderMap, Body)`
    |
note: there are multiple different versions of crate `axum_core` in the dependency graph
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/axum-core-0.5.0/src/response/into_response.rs:112:1
    |
112 | pub trait IntoResponse {
    | ^^^^^^^^^^^^^^^^^^^^^^ this is the trait that is needed
...
115 |     fn into_response(self) -> Response;
    |     ----------------------------------- the method is available for `(StatusCode, HeaderMap, axum::body::Body)` here
    |
   ::: worker/src/web.rs:2:5
    |
2   | use askama_axum::IntoResponse;
    |     ------------------------- `IntoResponse` imported here doesn't correspond to the right version of crate `axum_core`
    |
   ::: /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/axum-core-0.4.5/src/response/into_response.rs:112:1
    |
112 | pub trait IntoResponse {
    | ---------------------- this is the trait that was imported

error[E0599]: no method named `into_response` found for tuple `(StatusCode, HeaderMap, axum::body::Body)` in the current scope
   --> worker/src/web.rs:254:37
    |
254 |     (StatusCode::OK, headers, body).into_response()
    |                                     ^^^^^^^^^^^^^ method not found in `(StatusCode, HeaderMap, Body)`
    |
note: there are multiple different versions of crate `axum_core` in the dependency graph
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/axum-core-0.5.0/src/response/into_response.rs:112:1
    |
112 | pub trait IntoResponse {
    | ^^^^^^^^^^^^^^^^^^^^^^ this is the trait that is needed
...
115 |     fn into_response(self) -> Response;
    |     ----------------------------------- the method is available for `(StatusCode, HeaderMap, axum::body::Body)` here
    |
   ::: worker/src/web.rs:2:5
    |
2   | use askama_axum::IntoResponse;
    |     ------------------------- `IntoResponse` imported here doesn't correspond to the right version of crate `axum_core`
    |
   ::: /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/axum-core-0.4.5/src/response/into_response.rs:112:1
    |
112 | pub trait IntoResponse {
    | ---------------------- this is the trait that was imported

Some errors have detailed explanations: E0308, E0599.
For more information about an error, try `rustc --explain E0308`.
error: could not compile `janitor-worker` (lib) due to 5 previous errors
warning: build failed, waiting for other jobs to finish...
$
```

- - -

## After

```console
$ git checkout rust
branch 'rust' set up to track 'origin/rust'.
Switched to a new branch 'rust'
$ cargo clean; RUSTFLAGS=-Awarnings cargo build --manifest-path worker/Cargo.toml
     Removed 5344 files, 3.0GiB total
    Updating crates.io index
     Locking 2 packages to latest compatible versions
      Adding axum v0.7.9 (available: v0.8.1)
      Adding matchit v0.7.3
   Compiling proc-macro2 v1.0.92
[...]
   Compiling askama_axum v0.4.0
   Compiling axum v0.7.9
   Compiling gethostname v1.0.0
   Compiling ognibuild v0.0.32 (https://github.com/jelmer/ognibuild.git#0a5e3772)
   Compiling janitor-worker v0.0.0 (/tmp/janitor/worker)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 13s
$
```

- - -

## Break down

> There are multiple `axum-core` packages in your project.

- `askama_axum` v0.4.0 -> `axum-core` v0.4.5
- `axum` v0.8.1        -> `axum-core` v0.5.0

```console
$ cargo tree --manifest-path worker/Cargo.toml | grep axum
├── askama_axum v0.4.0
│   ├── axum-core v0.4.5
├── axum v0.8.1
│   ├── axum-core v0.5.0
│   ├── axum v0.8.1 (*)
$
$ cargo tree --manifest-path worker/Cargo.toml --invert axum-core
error: There are multiple `axum-core` packages in your project, and the specification `axum-core` is ambiguous.
Please re-run this command with one of the following specifications:
  axum-core@0.4.5
  axum-core@0.5.0
$
$ cargo tree --manifest-path worker/Cargo.toml --invert axum-core@0.4.5
axum-core v0.4.5
└── askama_axum v0.4.0
    └── janitor-worker v0.0.0 (/tmp/janitor/worker)
$
$ cargo tree --manifest-path worker/Cargo.toml --invert axum-core@0.5.0
axum-core v0.5.0
└── axum v0.8.1
    ├── janitor-worker v0.0.0 (/tmp/janitor/worker)
    └── ognibuild v0.0.32 (https://github.com/jelmer/ognibuild.git#0a5e3772)
        └── janitor-worker v0.0.0 (/tmp/janitor/worker)
$
```

- - -

`askama_axum` is the latest version (0.4.0), so need to downgrade `axum` to 0.7.9.

REF: List of all of [axum's versions](https://crates.io/crates/axum/versions) <!-- Not sure how to get this via `cargo`'s CLI! -->

```console
$ find . -name Cargo.toml -exec grep -inH 'axum' {} \; | grep -v workspace
./Cargo.toml:75:axum = "0.8"
./differ/Cargo.toml:27:axum-extra = { version = "0.10.0", features = ["typed-header"] }
./worker/Cargo.toml:30:askama_axum = { version = "0.4.0", features = ["serde-json", "serde-yaml", "humansize", "urlencode", "markdown"] }
$
$ cargo search askama_axum --limit 1 -q
askama_axum = "0.4.0"    # Axum integration for Askama templates
... and 15 crates more (use --limit N to see more)
$
$ cargo info axum@0.8 --verbose 2>/dev/null | grep 'axum-core@'
 +axum-core@0.5.0
$ cargo info axum@0.7.9 --verbose 2>/dev/null | grep 'axum-core@'
 +axum-core@0.4.5
$
```

- - -

Can either downgrade it for everything (aka package's workspace `./Cargo.toml`), or just that section (crate `./worker/Cargo.toml`).
As askama_axum is only in worker, will opt to alter that, rather than global.
