### PR TITLE
Make Makefile happy (build_protobuf)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ dev = [
     "pytest-cov",
     "python-subunit",
     "ruff==0.9.6",
+    "setuptools-protobuf",
     "setuptools-rust",
     "testing.postgresql",
     "testtools",


### PR DESCRIPTION
```console
$ make PYTHON=python
[...]
python setup.py build_protobuf
/opt/hostedtoolcache/Python/3.11.11/x64/lib/python3.11/site-packages/setuptools/config/pyprojecttoml.py:108: _BetaConfiguration: Support for `[tool.setuptools]` in `pyproject.toml` is still *beta*.
  warnings.warn(msg, _BetaConfiguration)
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help

error: invalid command 'build_protobuf'
make: *** [Makefile:10: build-inplace] Error 1
Error: Process completed with exit code 2.
```