### PR TITLE
Shebangs: Support venv

### DIFF
--- a/create-sbuild-chroot-schroot.py
+++ b/create-sbuild-chroot-schroot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import os

--- a/create-sbuild-chroot-unshare.py
+++ b/create-sbuild-chroot-unshare.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import os

--- a/reprocess-build-results.py
+++ b/reprocess-build-results.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Copyright (C) 2019-2020 Jelmer Vernooij <jelmer@jelmer.uk>
 #

--- a/reschedule.py
+++ b/reschedule.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Copyright (C) 2020 Jelmer Vernooij <jelmer@jelmer.uk>
 #

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 from setuptools import setup
 from setuptools_rust import Binding, RustBin, RustExtension
 


### PR DESCRIPTION
Check that inside virtual environment, its possible to see the python package `setuptools-rust`:
```console
# pip list | grep setuptools-rust
#
# . .venv/bin/activate
(.venv) #
(.venv) # pip list | grep setuptools-rust
setuptools-rust                1.10.2
(.venv) #
```

- - - 

If `python` is not used, `setup.py` has issues

```console
(.venv) # ./setup.py build_protobuf
Traceback (most recent call last):
  File "/root/janitor/./setup.py", line 3, in <module>
    from setuptools_rust import Binding, RustBin, RustExtension
ModuleNotFoundError: No module named 'setuptools_rust'
(.venv) #
(.venv) # python setup.py build_protobuf
/root/janitor/.venv/lib/python3.11/site-packages/setuptools/config/pyprojecttoml.py:108: _BetaConfiguration: Support for `[tool.setuptools]` in `pyproject.toml` is still *beta*.
  warnings.warn(msg, _BetaConfiguration)
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help

error: invalid command 'build_protobuf'
(.venv) #
```
- - -

Now after patching the file, it works both ways

```console
(.venv) # vim setup.py
(.venv) # git diff
diff --git a/setup.py b/setup.py
index 95dbd774..decf7bca 100755
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 from setuptools import setup
 from setuptools_rust import Binding, RustBin, RustExtension

(.venv) #
(.venv) # ./setup.py build_protobuf
/root/janitor/.venv/lib/python3.11/site-packages/setuptools/config/pyprojecttoml.py:108: _BetaConfiguration: Support for `[tool.setuptools]` in `pyproject.toml` is still *beta*.
  warnings.warn(msg, _BetaConfiguration)
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help

error: invalid command 'build_protobuf'
(.venv) #
```