### PR TITLE
Site: Add libjs-jquery-datatables

### DIFF
--- a/Dockerfile_site
+++ b/Dockerfile_site
@@ -25,6 +25,7 @@ RUN apt-get update --yes \
         pkg-config \
         protobuf-compiler \
        ## Extra packages
+        libjs-jquery-datatables \
         python3-gpg \
         python3-pip \
  && apt-get clean


### PR DESCRIPTION
```console
# janitor-site
INFO:aiozipkin:Zipkin address was not provided, using stub transport
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/dist-packages/aiohttp/web_urldispatcher.py", line 562, in __init__
    directory = Path(directory).expanduser().resolve(strict=True)
  File "/usr/lib/python3.13/pathlib/_local.py", line 672, in resolve
    return self.with_segments(os.path.realpath(self, strict=strict))
                              ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "<frozen posixpath>", line 445, in realpath
FileNotFoundError: [Errno 2] No such file or directory: '/usr/share/javascript/jquery-datatables'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/bin/janitor-site", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/usr/local/lib/python3.13/dist-packages/janitor/site/simple.py", line 725, in main
    sys.exit(asyncio.run(main_async(sys.argv[1:])))
             ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/asyncio/runners.py", line 195, in run
    return runner.run(main)
           ~~~~~~~~~~^^^^^^
  File "/usr/lib/python3.13/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
  File "/usr/local/lib/python3.13/dist-packages/janitor/site/simple.py", line 696, in main_async
    private_app, public_app = await create_app(
                              ^^^^^^^^^^^^^^^^^
    ...<11 lines>...
    )
    ^
  File "/usr/local/lib/python3.13/dist-packages/janitor/site/simple.py", line 537, in create_app
    app.router.add_static(
    ~~~~~~~~~~~~~~~~~~~~~^
        "/_static/images/datatables", "/usr/share/javascript/jquery-datatables/images"
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/local/lib/python3.13/dist-packages/aiohttp/web_urldispatcher.py", line 1203, in add_static
    resource = StaticResource(
        prefix,
    ...<6 lines>...
        append_version=append_version,
    )
  File "/usr/local/lib/python3.13/dist-packages/aiohttp/web_urldispatcher.py", line 564, in __init__
    raise ValueError(f"'{directory}' does not exist") from error
ValueError: '/usr/share/javascript/jquery-datatables/images' does not exist
```