### PR TITLE
Rust: Publish - Drop un-used argument

### DIFF
--- a/publish/src/bin/janitor-publish.rs
+++ b/publish/src/bin/janitor-publish.rs
@@ -46,10 +46,6 @@ struct Args {
     #[clap(long)]
     slowstart: bool,
 
-    /// Only publish changes that were reviewed.
-    #[clap(long)]
-    reviewed_only: bool,
-
     /// Limit number of pushes per cycle.
     #[clap(long)]
     push_limit: Option<usize>,


### PR DESCRIPTION
Related commit: e215bbc12c19a555c56ac9fa8083e88dfc77fd95