### PR TITLE
HTML: <head> work

### DIFF
--- a/py/janitor/site/templates/index.html
+++ b/py/janitor/site/templates/index.html
@@ -1,7 +1,4 @@
 {% extends "layout.html" %}
-{% block page_title %}
-    Index
-{% endblock page_title %}
 {% block body %}
     <div class="section" id="janitor">
         <h1>Janitor Instance</h1>

--- a/py/janitor/site/templates/index.html
+++ b/py/janitor/site/templates/index.html
@@ -1,4 +1,3 @@
-{% set layout = 'plain' %}
 {% extends "layout.html" %}
 {% block page_title %}
     Index

--- a/py/janitor/site/templates/layout.html
+++ b/py/janitor/site/templates/layout.html
@@ -2,9 +2,11 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-        <title>Janitor -
+        <title>Janitor
+            {% if self.page_title() | trim | length > 0 %}-
             {% block page_title %}
             {% endblock page_title %}
+            {% endif %}
         </title>
         <link rel="stylesheet" href="/_static/alabaster.css" type="text/css" />
         <link rel="stylesheet" href="/_static/lintian.css" type="text/css" />

--- a/py/janitor/site/templates/layout.html
+++ b/py/janitor/site/templates/layout.html
@@ -23,10 +23,10 @@
         <script src="/_static/chart.js"></script>
         <script src="/_static/janitor.js"></script>
         {% include "analytics.html" ignore missing without context %}
-        <div class="{% if layout != 'plain' %}document{% else %}plain-document{% endif %}">
+        <div class="{% if self.sidebar() | trim | length > 0 %}document{% else %}plain-document{% endif %}">
+            {% if self.sidebar() | trim | length > 0 %}
             {% block sidebar %}
             {% endblock sidebar %}
-            {% if layout != 'plain' %}
             <div class="documentwrapper">
                 <div class="bodywrapper">
             {% endif %}
@@ -34,7 +34,7 @@
                 {% block body %}
                 {% endblock body %}
             </main>
-            {% if layout != 'plain' %}
+            {% if self.sidebar() | trim | length > 0 %}
                 </div>
             </div>
             {% endif %}

--- a/py/janitor/site/templates/layout.html
+++ b/py/janitor/site/templates/layout.html
@@ -8,14 +8,15 @@
             {% endblock page_title %}
             {% endif %}
         </title>
+        <link rel="author" title="About these documents" href="/about" />
         <link rel="stylesheet" href="/_static/alabaster.css" type="text/css" />
         <link rel="stylesheet" href="/_static/lintian.css" type="text/css" />
-        <link rel="author" title="About these documents" href="/about" />
         <link rel="stylesheet" href="/_static/typeahead.css" type="text/css" />
         <link rel="stylesheet" href="/_static/pygments.css" type="text/css" />
         <link rel="stylesheet" href="/_static/datatables.css" type="text/css" />
         <meta name="viewport"
               content="width=device-width, initial-scale=0.9, maximum-scale=0.9" />
+        {% include "head.html" ignore missing without context %}
     </head>
     <body>
         <script src="/_static/jquery.js"></script>


### PR DESCRIPTION
- Adding for extra lines/data in <head> came about due to: https://github.com/jelmer/janitor/pull/949
- The sidebar came about noticing that `/about`'s layout was in a way where it was expecting a sidebar, but the block wasn't set