### PR TITLE
Fix #1054: campaign_config.command - list to str

### DIFF
--- a/py/janitor/runner.py
+++ b/py/janitor/runner.py
@@ -2142,7 +2142,7 @@ async def handle_candidates_upload(request):
                                 unknown_campaigns.append(campaign)
                                 await tr.rollback()
                                 continue
-                            command = campaign_config.command
+                            command = "".join(campaign_config.command)
                             if not command:
                                 logging.warning(
                                     "No command in candidate or campaign config"


### PR DESCRIPTION
```console
$ echo '''
[
    {
        "campaign": "fresh-snapshots",
        "codebase": "test"
    }
]
''' | curl -XPOST --data @- http://runner:9911/candidates
{"success": [], "invalid_command": [], "invalid_value": [], "unknown_campaigns": [], "unknown_codebases": ["test"], "unknown_publish_policies": []}$
```
- --  
```console
INFO:aiozipkin:Zipkin address was not provided, using stub transport
INFO:root:Public API listening on 0.0.0.0:9919
INFO:root:Admin API listening on 0.0.0.0:9911
WARNING:root:ignoring candidate test/fresh-snapshots; codebase unknown
INFO:aiohttp.access:10.89.0.106 [26/Mar/2025:10:10:32 +0000] "POST /candidates HTTP/1.1" 200 308 "-" "curl/8.13.0-rc2"
```