### PR TITLE
Runner: silver_platter.debian -> silver_platter

### DIFF
--- a/py/janitor/runner.py
+++ b/py/janitor/runner.py
@@ -426,11 +426,11 @@ class DebianBuilder(Builder):
         return env
 
     def additional_colocated_branches(self, main_branch):
-        from silver_platter.debian import (  # type: ignore
-            pick_additional_colocated_branches,
+        from silver_platter import (  # type: ignore
+            debian,
         )
 
-        return pick_additional_colocated_branches(main_branch)
+        return debian.pick_additional_colocated_branches(main_branch)
 
 
 BUILDER_CLASSES: list[type[Builder]] = [DebianBuilder, GenericBuilder]


### PR DESCRIPTION
```
$ python3
Python 3.13.2 (main, Mar 13 2025, 14:29:07) [GCC 14.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import silver_platter
>>> print(silver_platter.pick_additional_colocated_branches)
<built-in function pick_additional_colocated_branches>
>>> print(silver_platter.invalid)
Traceback (most recent call last):
  File "<python-input-3>", line 1, in <module>
    print(silver_platter.invalid)
          ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'silver_platter' has no attribute 'invalid'
>>>
```