### PR TITLE
Fix #1076: Fix --debug - Show more

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -32,11 +32,11 @@ pub fn init_logging(gcp_logging: bool, debug_mode: bool) {
     #[cfg(not(feature = "gcp"))]
     assert!(!gcp_logging, "GCP logging is not enabled");
 
-    if debug_mode {
-        env_logger::init();
+    use log::LevelFilter;
+    let level = if debug_mode {
+        LevelFilter::Debug
     } else {
-        env_logger::builder()
-            .filter(None, log::LevelFilter::Info)
-            .init();
-    }
+        LevelFilter::Info
+    };
+    env_logger::builder().filter(None, level).init();
 }


### PR DESCRIPTION
Putting in `println!("Current log level: {:?}", log::max_level());` gave:

```
$ /code/target/release/janitor-worker   --credentials=/janitor/credentials.json     --base-url=http://runner:9911     --external-address=worker     --site-port=9821 --port=9821 --tee
[...]
Current log level: Info

$ /code/target/release/janitor-worker   --credentials=/janitor/credentials.json     --base-url=http://runner:9911     --external-address=worker     --site-port=9821 --port=9821 --tee --debug
[...]
Current log level: Error
```