### PR TITLE
Add database schema export functionality for downstream projects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5334,6 +5334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -5907,6 +5908,7 @@ dependencies = [
  "native-tls",
  "once_cell",
  "percent-encoding",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -5917,6 +5919,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -7158,6 +7161,24 @@ dependencies = [
  "phf_codegen 0.11.3",
  "string_cache",
  "string_cache_codegen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.0",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "GPL-3.0+"
 repository = "https://github.com/jelmer/janitor.git"
 homepage = "https://github.com/jelmer/janitor"
 build = "build.rs"
+include = ["src/**/*", "py/janitor/state.sql", "py/janitor/debian/debian.sql", "README.md"]
 
 [dependencies]
 breezyshim = { workspace = true }
@@ -101,3 +102,4 @@ default = ["gcp", "gcs", "debian"]
 debian = ["dep:debversion"]
 gcp = ["stackdriver_logger", "gcs"]
 gcs = ["dep:google-cloud-storage", "dep:google-cloud-auth"]
+testing = ["sqlx/postgres", "sqlx/runtime-tokio-rustls"]

--- a/py/janitor/__init__.py
+++ b/py/janitor/__init__.py
@@ -26,6 +26,20 @@ __version__ = (0, 1, 0)
 version_string = ".".join(map(str, __version__))
 
 
+def get_core_schema() -> str:
+    """Return the core janitor database schema SQL."""
+    import pkg_resources
+
+    return pkg_resources.resource_string("janitor", "state.sql").decode("utf-8")
+
+
+def get_debian_schema() -> str:
+    """Return the Debian-specific database schema SQL."""
+    import pkg_resources
+
+    return pkg_resources.resource_string("janitor.debian", "debian.sql").decode("utf-8")
+
+
 def set_user_agent(user_agent):
     _mod_http.default_user_agent = lambda: user_agent
     _mod_urllib.AbstractHTTPHandler._default_headers["User-agent"] = user_agent

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod publish;
 pub mod queue;
 pub mod reprocess_logs;
 pub mod schedule;
+pub mod schema;
 pub mod state;
 pub mod vcs;
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,0 +1,77 @@
+/// Core janitor database schema
+pub const CORE_SCHEMA: &str = include_str!("../py/janitor/state.sql");
+
+/// Debian-specific database schema extensions
+pub const DEBIAN_SCHEMA: &str = include_str!("../py/janitor/debian/debian.sql");
+
+#[cfg(feature = "testing")]
+/// Set up a test database with core janitor schema
+pub async fn setup_test_database(pool: &sqlx::PgPool) -> Result<(), sqlx::Error> {
+    // Execute the entire schema as one statement - PostgreSQL can handle this
+    sqlx::query(CORE_SCHEMA).execute(pool).await?;
+    Ok(())
+}
+
+#[cfg(feature = "testing")]
+/// Set up a test database with Debian extensions
+pub async fn setup_debian_test_database(pool: &sqlx::PgPool) -> Result<(), sqlx::Error> {
+    setup_test_database(pool).await?;
+    sqlx::query(DEBIAN_SCHEMA).execute(pool).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_core_schema_is_not_empty() {
+        assert!(!CORE_SCHEMA.is_empty());
+        assert!(CORE_SCHEMA.len() > 1000); // Should be a substantial schema
+    }
+
+    #[test]
+    fn test_debian_schema_is_not_empty() {
+        assert!(!DEBIAN_SCHEMA.is_empty());
+        assert!(DEBIAN_SCHEMA.len() > 100); // Debian schema is smaller
+    }
+
+    #[test]
+    fn test_core_schema_contains_expected_tables() {
+        // Check for key tables
+        assert!(CORE_SCHEMA.contains("CREATE TABLE IF NOT EXISTS codebase"));
+        assert!(CORE_SCHEMA.contains("CREATE TABLE IF NOT EXISTS merge_proposal"));
+        assert!(CORE_SCHEMA.contains("CREATE TABLE IF NOT EXISTS run"));
+        assert!(CORE_SCHEMA.contains("CREATE TABLE IF NOT EXISTS change_set"));
+        assert!(CORE_SCHEMA.contains("CREATE TABLE IF NOT EXISTS queue"));
+        assert!(CORE_SCHEMA.contains("CREATE TABLE IF NOT EXISTS named_publish_policy"));
+        assert!(CORE_SCHEMA.contains("CREATE TABLE IF NOT EXISTS worker"));
+    }
+
+    #[test]
+    fn test_debian_schema_contains_expected_table() {
+        assert!(DEBIAN_SCHEMA.contains("CREATE TABLE debian_build"));
+        assert!(DEBIAN_SCHEMA.contains("run_id"));
+        assert!(DEBIAN_SCHEMA.contains("distribution"));
+        assert!(DEBIAN_SCHEMA.contains("version debversion"));
+        assert!(DEBIAN_SCHEMA.contains("source text"));
+    }
+
+    #[test]
+    fn test_core_schema_contains_sql_elements() {
+        // Check for various SQL elements
+        assert!(CORE_SCHEMA.contains("CREATE OR REPLACE VIEW"));
+        assert!(
+            CORE_SCHEMA.contains("CREATE INDEX") || CORE_SCHEMA.contains("CREATE UNIQUE INDEX")
+        );
+        assert!(CORE_SCHEMA.contains("CREATE OR REPLACE FUNCTION"));
+        assert!(CORE_SCHEMA.contains("references"));
+        assert!(CORE_SCHEMA.contains("not null"));
+    }
+
+    #[test]
+    fn test_schemas_are_different() {
+        assert_ne!(CORE_SCHEMA, DEBIAN_SCHEMA);
+        assert!(CORE_SCHEMA.len() > DEBIAN_SCHEMA.len());
+    }
+}

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,88 @@
+"""Tests for database schema export functionality."""
+
+from janitor import get_core_schema, get_debian_schema
+
+
+def test_get_core_schema():
+    """Test that get_core_schema returns valid SQL."""
+    schema = get_core_schema()
+
+    # Check that we got a non-empty string
+    assert isinstance(schema, str)
+    assert len(schema) > 0
+
+    # Check for key tables in the core schema
+    assert "CREATE TABLE IF NOT EXISTS codebase" in schema
+    assert "CREATE TABLE IF NOT EXISTS merge_proposal" in schema
+    assert "CREATE TABLE IF NOT EXISTS run" in schema
+    assert "CREATE TABLE IF NOT EXISTS change_set" in schema
+    assert "CREATE TABLE IF NOT EXISTS queue" in schema
+    assert "CREATE TABLE IF NOT EXISTS named_publish_policy" in schema
+    assert "CREATE TABLE IF NOT EXISTS worker" in schema
+
+    # Check for views
+    assert "CREATE OR REPLACE VIEW" in schema
+
+    # Check for functions
+    assert "CREATE OR REPLACE FUNCTION" in schema
+
+
+def test_get_debian_schema():
+    """Test that get_debian_schema returns valid SQL."""
+    schema = get_debian_schema()
+
+    # Check that we got a non-empty string
+    assert isinstance(schema, str)
+    assert len(schema) > 0
+
+    # Check for the debian_build table
+    assert "CREATE TABLE debian_build" in schema
+
+    # Check for expected columns
+    assert "run_id" in schema
+    assert "distribution" in schema
+    assert "version debversion" in schema
+    assert "source text" in schema
+    assert "binary_packages" in schema
+
+
+def test_schemas_are_different():
+    """Test that core and debian schemas are different."""
+    core = get_core_schema()
+    debian = get_debian_schema()
+
+    assert core != debian
+    assert len(core) > len(debian)  # Core schema should be much larger
+
+
+def test_core_schema_sql_syntax():
+    """Test that core schema contains valid SQL syntax markers."""
+    schema = get_core_schema()
+
+    # Check for common SQL keywords
+    sql_keywords = [
+        "CREATE",
+        "TABLE",
+        "INDEX",
+        "VIEW",
+        "FUNCTION",
+        "references",
+        "not null",
+    ]
+
+    for keyword in sql_keywords:
+        assert keyword in schema, (
+            f"Expected SQL keyword '{keyword}' not found in schema"
+        )
+
+
+def test_debian_schema_sql_syntax():
+    """Test that debian schema contains valid SQL syntax markers."""
+    schema = get_debian_schema()
+
+    # Check for basic SQL structure
+    assert "CREATE TABLE" in schema
+    assert "CREATE INDEX" in schema
+    assert "not null" in schema
+    assert ");" in schema  # End of table definition
+    assert "references run (id)" in schema  # Foreign key reference


### PR DESCRIPTION
This implements the database schema export feature requested in janitor-request.schema.md to enable downstream projects like debian-janitor to access the official database schemas for testing.